### PR TITLE
refactor: drop error code constants

### DIFF
--- a/lib/config_handler.py
+++ b/lib/config_handler.py
@@ -1,23 +1,33 @@
 from __future__ import annotations
 
+"""Configuration handling for the oAW to RST generator."""
+
 import argparse
 import json
 from dataclasses import dataclass
-from typing import Dict
 from pathlib import Path
+from typing import Dict
 
 from .utils import report_error
 
 
+# Default location of the configuration file relative to the script.
+DEFAULT_CONFIG_RELATIVE_PATH = Path("config/config.json")
+
+
 @dataclass
 class Config:
+    """Resolved configuration values for the generator."""
+
     component: str
     test_path: Path
     spec_path: Path
     group_name_mappings: Dict[str, str]
 
 
-def load_config_with_overrides(script_path: Path) -> Config:
+def _parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments for the generator."""
+
     parser = argparse.ArgumentParser(description="oAW to RST generator")
     parser.add_argument(
         "--config",
@@ -28,31 +38,79 @@ def load_config_with_overrides(script_path: Path) -> Config:
     parser.add_argument("--component", type=str, help="Component name", default=None)
     parser.add_argument("--test_path", type=str, help="Path to test files", default=None)
     parser.add_argument("--spec_path", type=str, help="Path to spec files", default=None)
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    # Determine config.json location (default in ./config/config.json next to script)
-    if args.config:
-        specified_path = Path(args.config)
-        script_dir = script_path.parent
-        config_path: Path = (
-            specified_path
-            if specified_path.is_absolute()
-            else (script_dir / specified_path).resolve()
+
+def _resolve_config_path(script_path: Path, config_arg: str | None) -> tuple[Path, Path]:
+    """Determine the configuration file path and its directory."""
+
+    script_dir = script_path.parent
+    if config_arg:
+        specified = Path(config_arg)
+        config_path = (
+            specified if specified.is_absolute() else (script_dir / specified).resolve()
         )
-        config_dir: Path = config_path.parent
-        if not config_path.exists():
-            report_error(config_path, 1, 1001, f"config file not found: {config_path}")
     else:
-        script_dir = script_path.parent
-        config_dir = script_dir / "config"
-        config_path = config_dir / "config.json"
-        if not config_path.exists():
-            report_error(
-                config_path, 1, 1001, "config.json not found in ./config next to oaw_to_rst.py"
-            )
+        config_path = script_dir / DEFAULT_CONFIG_RELATIVE_PATH
+    if not config_path.exists():
+        report_error(config_path, 1, f"config file not found: {config_path}")
+    return config_path, config_path.parent
 
-    with config_path.open("r", encoding="utf-8") as f:
-        raw = json.load(f)
+
+def _load_raw_config(config_path: Path) -> Dict[str, object]:
+    """Load raw JSON configuration."""
+
+    with config_path.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _normalize_group_mappings(
+    config_path: Path, raw_mappings: object
+) -> Dict[str, str]:
+    """Validate and normalize group name mappings."""
+
+    if not isinstance(raw_mappings, dict) or not raw_mappings:
+        report_error(
+            config_path,
+            1,
+            "Invalid or missing 'group_name_mappings' in configuration",
+        )
+    mappings: Dict[str, str] = {}
+    for key, value in raw_mappings.items():
+        if not isinstance(key, str) or not isinstance(value, str) or not key.strip():
+            report_error(
+                config_path,
+                1,
+                "'group_name_mappings' must map non-empty strings to strings",
+            )
+        mappings[key.strip().lower()] = value.strip()
+    return mappings
+
+
+def _resolve_path(base_dir: Path, path_str: str) -> Path:
+    """Convert ``path_str`` to an absolute :class:`Path` relative to ``base_dir``."""
+
+    path = Path(path_str)
+    return path if path.is_absolute() else (base_dir / path).resolve()
+
+
+def load_config_with_overrides(script_path: Path) -> Config:
+    """Load configuration from JSON and apply CLI overrides.
+
+    Parameters
+    ----------
+    script_path:
+        Absolute path to the running script.
+
+    Returns
+    -------
+    Config
+        Configuration object with absolute paths and normalized mappings.
+    """
+
+    args = _parse_arguments()
+    config_path, config_dir = _resolve_config_path(script_path, args.config)
+    raw = _load_raw_config(config_path)
 
     component = args.component or raw.get("component")
     test_path_raw = args.test_path or raw.get("test_path")
@@ -60,34 +118,40 @@ def load_config_with_overrides(script_path: Path) -> Config:
     group_name_mappings_raw = raw.get("group_name_mappings")
 
     if not component or not isinstance(component, str):
-        report_error(config_path, 1, 1002, "Invalid or missing 'component' in configuration")
-
+        report_error(
+            config_path,
+            1,
+            "Invalid or missing 'component' in configuration",
+        )
     if not test_path_raw or not isinstance(test_path_raw, str):
-        report_error(config_path, 1, 1003, "Invalid or missing 'test_path' in configuration")
-
+        report_error(
+            config_path,
+            1,
+            "Invalid or missing 'test_path' in configuration",
+        )
     if not spec_path_raw or not isinstance(spec_path_raw, str):
-        report_error(config_path, 1, 1004, "Invalid or missing 'spec_path' in configuration")
+        report_error(
+            config_path,
+            1,
+            "Invalid or missing 'spec_path' in configuration",
+        )
 
-    # group_name_mappings is mandatory and not overridable via CLI
-    if not isinstance(group_name_mappings_raw, dict) or not group_name_mappings_raw:
-        report_error(config_path, 1, 1005, "Invalid or missing 'group_name_mappings' in configuration")
-    # Normalize keys to lowercase and ensure values are strings
-    group_name_mappings: Dict[str, str] = {}
-    for k, v in group_name_mappings_raw.items():
-        if not isinstance(k, str) or not isinstance(v, str) or not k.strip():
-            report_error(config_path, 1, 1006, "'group_name_mappings' must map non-empty strings to strings")
-        group_name_mappings[k.strip().lower()] = v.strip()
+    group_name_mappings = _normalize_group_mappings(
+        config_path, group_name_mappings_raw
+    )
 
-    test_path = Path(test_path_raw)
-    spec_path = Path(spec_path_raw)
-
-    if not test_path.is_absolute():
-        test_path = (config_dir / test_path).resolve()
-    if not spec_path.is_absolute():
-        spec_path = (config_dir / spec_path).resolve()
+    test_path = _resolve_path(config_dir, test_path_raw)
+    spec_path = _resolve_path(config_dir, spec_path_raw)
 
     print(f"Component: {component}")
     print(f"Test path: {test_path}")
     print(f"Spec path: {spec_path}")
     print("")
-    return Config(component=component, test_path=test_path, spec_path=spec_path, group_name_mappings=group_name_mappings)
+
+    return Config(
+        component=component,
+        test_path=test_path,
+        spec_path=spec_path,
+        group_name_mappings=group_name_mappings,
+    )
+

--- a/lib/file_generator.py
+++ b/lib/file_generator.py
@@ -23,7 +23,7 @@ def find_toc_rst(component: str, spec_path: Path) -> Path:
     toc_name = f"{component}_component_test.rst"
     candidate = spec_path / toc_name
     if not candidate.exists():
-        report_error(candidate, 1, 1301, f"{toc_name} not found in {spec_path}")
+        report_error(candidate, 1, f"{toc_name} not found in {spec_path}")
     print("Table of content rst file:")
     print(f"{candidate}")
     print("")
@@ -42,7 +42,7 @@ def cleanup_generated_group_files(component: str, toc_path: Path) -> None:
             file.unlink()
             print(f"{file}")
         except Exception as ex:
-            report_error(file, 1, 1302, f"Failed to delete file: {ex}")
+            report_error(file, 1, f"Failed to delete file: {ex}")
 
 
 def remove_generated_lines_from_toc(component: str, toc_path: Path) -> None:
@@ -51,14 +51,14 @@ def remove_generated_lines_from_toc(component: str, toc_path: Path) -> None:
     try:
         text = toc_path.read_text(encoding="utf-8")
     except Exception as ex:
-        report_error(toc_path, 1, 1303, f"Failed to read TOC file: {ex}")
+        report_error(toc_path, 1, f"Failed to read TOC file: {ex}")
     lines = text.splitlines()
     prefix = f"{component}_oAW_"
     filtered = [ln for ln in lines if not ln.lstrip().startswith(prefix)]
     try:
         toc_path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
     except Exception as ex:
-        report_error(toc_path, 1, 1304, f"Failed to write TOC file: {ex}")
+        report_error(toc_path, 1, f"Failed to write TOC file: {ex}")
 
 
 def append_group_links_to_toc(
@@ -69,7 +69,7 @@ def append_group_links_to_toc(
     try:
         text = toc_path.read_text(encoding="utf-8")
     except Exception as ex:
-        report_error(toc_path, 1, 1303, f"Failed to read TOC file: {ex}")
+        report_error(toc_path, 1, f"Failed to read TOC file: {ex}")
 
     appended_lines: List[str] = []
     for group in groups:
@@ -83,7 +83,7 @@ def append_group_links_to_toc(
     try:
         toc_path.write_text(text, encoding="utf-8")
     except Exception as ex:
-        report_error(toc_path, 1, 1304, f"Failed to write TOC file: {ex}")
+        report_error(toc_path, 1, f"Failed to write TOC file: {ex}")
 
 
 def format_tests_value(tags: List[str], delimiter: str, max_width: int, indent_spaces: int) -> str:
@@ -151,7 +151,6 @@ def generate_group_rst(
         report_warning(
             path,
             header.requirements_line,
-            2001,
             "Missing Requirements content; emitting TODO in test specification rst file",
         )
         return (
@@ -159,14 +158,13 @@ def generate_group_rst(
         )
 
     def build_field_lines(
-        label: str, content: str, line_no: int, code: int, path: Path
+        label: str, content: str, line_no: int, path: Path
     ) -> List[str]:
         if content:
             return format_multiline_field(label, content, base_indent_spaces=6)
         report_warning(
             path,
             line_no,
-            code,
             f"Missing {label} content; emitting TODO in test specification rst file",
         )
         return format_multiline_field(
@@ -183,9 +181,15 @@ def generate_group_rst(
         counter += 1
 
         tests_line = build_tests_line(p, hdr)
-        desc_lines = build_field_lines("Description", hdr.description, hdr.desc_line, 2002, p)
-        input_lines = build_field_lines("Input", hdr.input_text, hdr.input_line, 2003, p)
-        output_lines = build_field_lines("Output", hdr.output_text, hdr.output_line, 2004, p)
+        desc_lines = build_field_lines(
+            "Description", hdr.description, hdr.desc_line, p
+        )
+        input_lines = build_field_lines(
+            "Input", hdr.input_text, hdr.input_line, p
+        )
+        output_lines = build_field_lines(
+            "Output", hdr.output_text, hdr.output_line, p
+        )
 
         steps.append(
             {
@@ -229,5 +233,5 @@ def generate_group_rst(
         out_path.write_text(content, encoding="utf-8")
         print(f"{out_path}")
     except Exception as ex:
-        report_error(out_path, 1, 1501, f"Failed to write group RST: {ex}")
+        report_error(out_path, 1, f"Failed to write group RST: {ex}")
     return out_path

--- a/lib/file_handler.py
+++ b/lib/file_handler.py
@@ -15,9 +15,17 @@ def validate_paths(config: Config) -> None:
     """Verify that configured test/spec directories exist."""
 
     if not config.test_path.exists() or not config.test_path.is_dir():
-        report_error(config.test_path, 1, 1101, "'test_path' does not exist or is not a directory")
+        report_error(
+            config.test_path,
+            1,
+            "'test_path' does not exist or is not a directory",
+        )
     if not config.spec_path.exists() or not config.spec_path.is_dir():
-        report_error(config.spec_path, 1, 1102, "'spec_path' does not exist or is not a directory")
+        report_error(
+            config.spec_path,
+            1,
+            "'spec_path' does not exist or is not a directory",
+        )
 
 
 def discover_tsc_files(config: Config) -> List[Path]:
@@ -46,7 +54,11 @@ def group_tsc_files_by_group(component: str, tsc_files: List[Path]) -> Dict[str,
         stem = file_path.stem
         parts = stem.split("_")
         if len(parts) < 3 or parts[0] != component:
-            collect_error(file_path, 1, 1201, "No valid group token in filename")
+            collect_error(
+                file_path,
+                1,
+                "No valid group token in filename",
+            )
             continue
         group = parts[1]
         groups.setdefault(group, []).append(file_path)
@@ -57,6 +69,8 @@ def group_tsc_files_by_group(component: str, tsc_files: List[Path]) -> Dict[str,
 
 @dataclass
 class TscHeader:
+    """Represents parsed header metadata from a ``.tsc`` file."""
+
     description: str
     input_text: str
     output_text: str
@@ -73,7 +87,7 @@ def parse_tsc_header(path: Path) -> TscHeader | None:
     try:
         text = path.read_text(encoding="utf-8")
     except Exception as ex:
-        collect_error(path, 1, 1401, f"Failed to read .tsc file: {ex}")
+        collect_error(path, 1, f"Failed to read .tsc file: {ex}")
         return None
 
     lines = text.splitlines()
@@ -107,7 +121,11 @@ def parse_tsc_header(path: Path) -> TscHeader | None:
             if header_match:
                 name = header_match.group(1).lower()
                 if order_index >= len(expected_order) or name != expected_order[order_index]:
-                    collect_error(path, idx + 1, 1402, f"Unexpected or out-of-order section '{name}'")
+                    collect_error(
+                        path,
+                        idx + 1,
+                        f"Unexpected or out-of-order section '{name}'",
+                    )
                     return None
                 current = name
                 order_index += 1
@@ -115,20 +133,28 @@ def parse_tsc_header(path: Path) -> TscHeader | None:
                 header_lines[name] = idx + 1
             else:
                 if current is None:
-                    collect_error(path, idx + 1, 1403, "Header must start with 'Description'")
+                    collect_error(
+                        path,
+                        idx + 1,
+                        "Header must start with 'Description'",
+                    )
                     return None
                 sections[current].append(content.rstrip())
             idx += 1
             continue
         else:
             if order_index == 0:
-                collect_error(path, 1, 1404, "Header missing")
+                collect_error(path, 1, "Header missing")
                 return None
             break
 
     missing_tokens = [tok for tok in expected_order if tok not in seen_tokens]
     if missing_tokens:
-        collect_error(path, 1, 1405, f"Missing header section(s): {', '.join(t.capitalize() for t in missing_tokens)}")
+        collect_error(
+            path,
+            1,
+            f"Missing header section(s): {', '.join(t.capitalize() for t in missing_tokens)}",
+        )
         return None
 
     req_line = " ".join(sections["requirements"]).replace(",", " ")

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -16,8 +16,11 @@ RESET = "\033[0m"
 HAS_WARNINGS: bool = False
 HAS_ERRORS: bool = False
 
+EXIT_FAILURE = 1
+
 
 def _print_banner(text: str, color: str) -> None:
+    """Render a colored banner to stdout."""
     print(f"{color}{text}{RESET}")
 
 
@@ -41,17 +44,17 @@ def print_final_status_banner() -> None:
         )
 
 
-def report_error(file: Path, line: int, code: int, message: str) -> None:
+def report_error(file: Path, line: int, message: str) -> None:
     """Log a fatal error, show the final banner, and exit."""
     global HAS_ERRORS
     HAS_ERRORS = True
     print(f"{file}:{line}: (ERROR) {message}", file=sys.stderr)
     # Print banner at the end before exiting
     print_final_status_banner()
-    sys.exit(1)
+    sys.exit(EXIT_FAILURE)
 
 
-def collect_error(file: Path, line: int, code: int, message: str) -> None:
+def collect_error(file: Path, line: int, message: str) -> None:
     """Record a non-fatal error and continue execution.
 
     Used for aggregating errors across multiple .tsc files so developers can
@@ -67,7 +70,7 @@ def has_errors() -> bool:
     return HAS_ERRORS
 
 
-def report_warning(file: Path, line: int, code: int, message: str) -> None:
+def report_warning(file: Path, line: int, message: str) -> None:
     """Log a warning without halting execution."""
     global HAS_WARNINGS
     HAS_WARNINGS = True

--- a/oaw_to_rst.py
+++ b/oaw_to_rst.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from lib.config_handler import Config, load_config_with_overrides
+from lib.config_handler import load_config_with_overrides
 from lib.file_handler import (
     validate_paths,
     discover_tsc_files,
@@ -27,8 +27,13 @@ from lib.file_generator import (
 )
 from lib.utils import print_final_status_banner, has_errors
 
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
 
 def main() -> int:
+    """Run the oAW to RST generation workflow."""
+
     print("Running oAW to RST generator")
     print("----------------------------")
     script_path = Path(__file__).resolve()
@@ -37,7 +42,7 @@ def main() -> int:
 
     tsc_files = discover_tsc_files(config)
     if not tsc_files:
-        return 0
+        return EXIT_SUCCESS
 
     tsc_file_groups = group_tsc_files_by_group(config.component, tsc_files)
     parsed_groups = parse_all_headers(tsc_file_groups)
@@ -45,23 +50,27 @@ def main() -> int:
     # If any .tsc parsing/grouping errors were collected, report and stop
     if has_errors():
         print_final_status_banner()
-        return 1
+        return EXIT_FAILURE
 
     toc_path = find_toc_rst(config.component, config.spec_path)
 
     cleanup_generated_group_files(config.component, toc_path)
     remove_generated_lines_from_toc(config.component, toc_path)
-    append_group_links_to_toc(config.component, list(tsc_file_groups.keys()), toc_path, config.group_name_mappings)
+    append_group_links_to_toc(
+        config.component, list(tsc_file_groups.keys()), toc_path, config.group_name_mappings
+    )
 
     template_dir = script_path.parent / "config" / "templates"
     toc_dir = toc_path.parent
-    print(f"Generated test group rst files:")
+    print("Generated test group rst files:")
     for group_name, parsed_list in parsed_groups.items():
-        generate_group_rst(config.component, group_name, parsed_list, toc_dir, template_dir, config.group_name_mappings)
+        generate_group_rst(
+            config.component, group_name, parsed_list, toc_dir, template_dir, config.group_name_mappings
+        )
 
     # Print final banner based on warnings/errors
     print_final_status_banner()
-    return 0
+    return EXIT_SUCCESS
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove error code constants and streamline error/warning helpers
- return a single status code for any fatal error

## Testing
- `python run_test.py`


------
https://chatgpt.com/codex/tasks/task_b_68b32199bf948320a7c8139cb7bc3628